### PR TITLE
fix: streaming for OpenAI, DeepSeek, and Gemini providers

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -3,5 +3,5 @@ return {
     name = "koassistant",
     fullname = _("KOAssistant"),
     description = _([[A powerful plugin that lets you interact with AI language models (Claude, GPT-4, etc.) while reading. Ask questions about text, get translations, summaries, explanations and more.]]),
-    version = "0.6.0",
+    version = "0.6.1",
 }


### PR DESCRIPTION
Streaming was only working for Anthropic after the unified request system refactor. Fixed multiple issues:

- Fix JSON null handling in extractContentFromSSE: finish_reason being JSON null was incorrectly treated as truthy in KOReader's JSON parser, causing content extraction to always fail for OpenAI/DeepSeek
- Fix CRLF line ending handling in SSE parser: properly skip both \r and \n for Windows-style line endings
- Add flexible data: prefix detection for SSE (handles both "data: " and "data:" formats)
- Fix fresh-start streaming: re-require SSL modules in subprocess to ensure proper initialization after fork (was failing until a non-streaming request happened first)

Files changed:
- stream_handler.lua: SSE parsing fixes (lines 354-380, 482-495)
- api_handlers/base.lua: subprocess SSL initialization (lines 106-116)