### PR TITLE
Disable web search for Explain action

### DIFF
--- a/prompts/actions.lua
+++ b/prompts/actions.lua
@@ -169,6 +169,7 @@ Actions.DOUBLE_GATED_FLAGS = {
 Actions.highlight = {
     explain = {
         id = "explain",
+        enable_web_search = false,
         text = _("Explain"),
         description = _("Explains the selected passage clearly, matching the tone of the source material."),
         context = "highlight",


### PR DESCRIPTION
## Summary
Disable web search for the built-in Explain highlight action.

## Why
When global web search is enabled, Explain was inheriting that setting while other basic highlight helpers already force web search off. For Gemini, that can send Explain down the Google Search grounding path and trigger quota/resource-exhausted errors even when normal generation works. Web search still can be enabled through Action Edit but I think majority of people wouldn't use paid tiers for this.

## Change
- Set "enable_web_search = false" for the "Explain" action