### PR TITLE
Add OpenAI Subscription login via Codex device auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ return {
 
 > **Note:** GUI-entered keys take priority over file-based keys. The API Keys menu shows `[set]` for GUI keys and `(file)` for keys from apikeys.lua. Provider pickers only list providers that have a key configured (plus local/no-key providers like Ollama), so the menus stay short.
 
+**Option C: OpenAI Subscription (device login)**
+
+If your ChatGPT plan includes Codex access, go to **Tools → KOAssistant → API Keys → OpenAI Subscription** and tap **Connect**. KOAssistant displays an OpenAI verification URL and one-time code; it never tries to open a browser on the e-reader. Open the URL on another device, enter the code, then return to KOReader and tap **Check authorization**. This is separate from the OpenAI API-key provider and does not use API credits.
+
+KOAssistant stores the OAuth access/refresh tokens in its settings and never displays or logs them. They are excluded from ordinary backups; enabling **Include API keys** includes them, and **Reset API Keys** disconnects the subscription. Subscription access depends on OpenAI's Codex backend and eligible ChatGPT account entitlements, so available models and service behavior may change.
+
 See [Supported Providers](#supported-providers--settings) for full list with links to get API keys.
 
 > **Free Options Available:** Don't want to pay? Groq, Gemini, and Ollama offer free tiers. See [Free Tier Providers](#free-tier-providers).

--- a/koassistant_api/defaults.lua
+++ b/koassistant_api/defaults.lua
@@ -73,6 +73,14 @@ local ProviderDefaults = {
             max_tokens = 16384
         }
     },
+    openai_codex = {
+        provider = "openai_codex",
+        model = getDefaultModel("openai_codex"),
+        base_url = "https://chatgpt.com/backend-api/codex/responses",
+        additional_parameters = {
+            max_tokens = 16384
+        }
+    },
     deepseek = {
         provider = "deepseek",
         model = getDefaultModel("deepseek"),

--- a/koassistant_api/openai_codex.lua
+++ b/koassistant_api/openai_codex.lua
@@ -1,0 +1,108 @@
+local OpenAIHandler = require("koassistant_api.openai")
+local ResponseParser = require("koassistant_api.response_parser")
+local DebugUtils = require("koassistant_debug_utils")
+local ModelConstraints = require("model_constraints")
+local OAuth = require("koassistant_openai_codex_oauth")
+local json = require("json")
+
+local CodexHandler = OpenAIHandler:new()
+
+local CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
+local USER_AGENT = "codex_cli_rs/0.0.0 (KOAssistant)"
+local ORIGINATOR = "codex_cli_rs"
+
+local function buildHeaders(config)
+    local account_id = config.oauth and config.oauth.chatgpt_account_id
+    return {
+        ["Content-Type"] = "application/json",
+        ["Authorization"] = "Bearer " .. (config.api_key or ""),
+        ["ChatGPT-Account-ID"] = account_id or "",
+        ["User-Agent"] = USER_AGENT,
+        ["originator"] = ORIGINATOR,
+    }
+end
+
+function CodexHandler:buildRequestBody(message_history, config)
+    local model = config.model or "gpt-5.6-terra"
+    local built = self:buildResponsesRequest(message_history, config, model)
+    built.url = CODEX_URL
+    built.provider = "openai_codex"
+    built.headers = buildHeaders(config)
+    -- ChatGPT's Codex backend chooses its own output ceiling and rejects the
+    -- public Responses API's max_output_tokens field.
+    built.body.max_output_tokens = nil
+    return built
+end
+
+function CodexHandler:query(message_history, config)
+    if not config or not config.api_key then
+        return "Error: Missing OAuth access token in configuration"
+    end
+    if not (config.oauth and config.oauth.chatgpt_account_id) then
+        return "Error: Missing ChatGPT account id in OAuth configuration"
+    end
+
+    local built = self:buildRequestBody(message_history, config)
+    local request_body = built.body
+    local base_url = built.url
+    local headers = built.headers
+    local use_streaming = config.features and config.features.enable_streaming ~= false
+
+    if config and config.features and config.features.debug then
+        ModelConstraints.logAdjustments("OpenAI Subscription", built.adjustments)
+        DebugUtils.print("OpenAI Codex Request Body:", request_body, config)
+        print("Streaming enabled:", use_streaming and "yes" or "no")
+    end
+
+    local requestBody = json.encode(request_body)
+    headers["Content-Length"] = tostring(#requestBody)
+
+    if use_streaming then
+        local stream_request_body = json.decode(requestBody)
+        stream_request_body.stream = true
+        local stream_body = json.encode(stream_request_body)
+        headers["Content-Length"] = tostring(#stream_body)
+        headers["Accept"] = "text/event-stream"
+
+        local stream_fn = self:backgroundRequest(base_url, headers, stream_body)
+        local effort = request_body.reasoning and request_body.reasoning.effort
+        if effort then
+            return {
+                _stream_fn = stream_fn,
+                _reasoning_requested = true,
+                _reasoning_effort = effort,
+            }
+        end
+        return stream_fn
+    end
+
+    local parser_key = built.parser or "openai_responses"
+    local reasoning_effort = request_body.reasoning and request_body.reasoning.effort
+    local debug_enabled = config and config.features and config.features.debug
+
+    local response_parser = function(response)
+        if debug_enabled then
+            DebugUtils.print("OpenAI Codex Parsed Response:", response, config)
+        end
+        local parse_success, result, reasoning, web_search_used = ResponseParser:parseResponse(response, parser_key)
+        if not parse_success then
+            return false, "Error: " .. result
+        end
+        if reasoning_effort then
+            return true, result, { _requested = true, effort = reasoning_effort }, web_search_used
+        end
+        return true, result, reasoning, web_search_used
+    end
+
+    return {
+        _background_fn = self:backgroundRequest(base_url, headers, requestBody),
+        _non_streaming = true,
+        _response_parser = response_parser,
+    }
+end
+
+function CodexHandler:getOAuthModule()
+    return OAuth
+end
+
+return CodexHandler

--- a/koassistant_api/openai_codex.lua
+++ b/koassistant_api/openai_codex.lua
@@ -1,15 +1,19 @@
 local OpenAIHandler = require("koassistant_api.openai")
+local BaseHandler = require("koassistant_api.base")
 local ResponseParser = require("koassistant_api.response_parser")
 local DebugUtils = require("koassistant_debug_utils")
 local ModelConstraints = require("model_constraints")
 local OAuth = require("koassistant_openai_codex_oauth")
+local ffi = require("ffi")
 local json = require("json")
+local meta = require("_meta")
 
 local CodexHandler = OpenAIHandler:new()
 
 local CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
-local USER_AGENT = "codex_cli_rs/0.0.0 (KOAssistant)"
-local ORIGINATOR = "codex_cli_rs"
+local USER_AGENT = "KOAssistant/" .. tostring(meta.version or "unknown")
+    .. " (unofficial OpenAI Codex subscription client)"
+local ORIGINATOR = "koassistant"
 
 local function buildHeaders(config)
     local account_id = config.oauth and config.oauth.chatgpt_account_id
@@ -20,6 +24,51 @@ local function buildHeaders(config)
         ["User-Agent"] = USER_AGENT,
         ["originator"] = ORIGINATOR,
     }
+end
+
+-- Codex requires SSE even when KOAssistant's caller expects one buffered
+-- response. Keep that transport quirk local while reusing BaseHandler's
+-- fork-safe HTTP implementation and pipe protocol.
+local function makeCollectedRequest(url, headers, body, response_transform)
+    local resolved_ip = BaseHandler.resolveForSubprocess(url)
+    return function(pid, child_write_fd)
+        if not pid or not child_write_fd then return end
+
+        local subprocess_ok, subprocess_err = pcall(function()
+            local status_code, response_body = BaseHandler.fetchInSubprocess(url, {
+                method = "POST",
+                headers = headers or {},
+                body = body or "",
+                resolved_ip = resolved_ip,
+                timeout = 180,
+            })
+            if status_code ~= 200 then
+                local message = status_code
+                    and BaseHandler.formatNon200(status_code, response_body)
+                    or ("Connection error: " .. tostring(response_body))
+                BaseHandler.writeAllToFD(child_write_fd,
+                    string.format("\r\n%s%s\n\n", BaseHandler.PROTOCOL_NON_200, message))
+                return
+            end
+
+            local transform_ok, transformed = pcall(response_transform, response_body)
+            if not transform_ok then
+                BaseHandler.writeAllToFD(child_write_fd,
+                    string.format("\r\n%sResponse transform error: %s\n\n",
+                        BaseHandler.PROTOCOL_NON_200, tostring(transformed)))
+                return
+            end
+            BaseHandler.writeAllToFD(child_write_fd, tostring(transformed or ""))
+        end)
+
+        if not subprocess_ok then
+            BaseHandler.writeAllToFD(child_write_fd,
+                string.format("\r\n%sSubprocess error: %s\n\n",
+                    BaseHandler.PROTOCOL_NON_200, tostring(subprocess_err)))
+        end
+        ffi.C.close(child_write_fd)
+        pcall(function() ffi.C._exit(0) end)
+    end
 end
 
 function CodexHandler:buildRequestBody(message_history, config)
@@ -54,17 +103,16 @@ function CodexHandler:query(message_history, config)
         print("Streaming enabled:", use_streaming and "yes" or "no")
     end
 
+    -- This backend rejects non-streaming requests. Always use SSE on the wire;
+    -- non-streaming callers (including book-tool gather rounds) collect it in
+    -- the subprocess and receive an ordinary Responses object.
+    request_body.stream = true
     local requestBody = json.encode(request_body)
     headers["Content-Length"] = tostring(#requestBody)
+    headers["Accept"] = "text/event-stream"
 
     if use_streaming then
-        local stream_request_body = json.decode(requestBody)
-        stream_request_body.stream = true
-        local stream_body = json.encode(stream_request_body)
-        headers["Content-Length"] = tostring(#stream_body)
-        headers["Accept"] = "text/event-stream"
-
-        local stream_fn = self:backgroundRequest(base_url, headers, stream_body)
+        local stream_fn = self:backgroundRequest(base_url, headers, requestBody)
         local effort = request_body.reasoning and request_body.reasoning.effort
         if effort then
             return {
@@ -95,7 +143,8 @@ function CodexHandler:query(message_history, config)
     end
 
     return {
-        _background_fn = self:backgroundRequest(base_url, headers, requestBody),
+        _background_fn = makeCollectedRequest(
+            base_url, headers, requestBody, ResponseParser.collectResponsesSSE),
         _non_streaming = true,
         _response_parser = response_parser,
     }

--- a/koassistant_api/response_parser.lua
+++ b/koassistant_api/response_parser.lua
@@ -117,6 +117,115 @@ local function formatCitations(citations)
     return "\n\n---\n**Sources:**\n\n" .. table.concat(parts, "\n")
 end
 
+-- Collect a mandatory Responses SSE stream into the ordinary response object used
+-- by non-streaming parsers. Terminal output is authoritative; output_item.done
+-- events backfill items omitted from response.completed at their protocol index.
+local function responsesOutputItemKey(item)
+    if type(item) ~= "table" then return nil end
+    local item_type = tostring(item.type or "item")
+    if type(item.id) == "string" and item.id ~= "" then
+        return item_type .. ":id:" .. item.id
+    end
+    if item_type == "function_call" and type(item.call_id) == "string" and item.call_id ~= "" then
+        return item_type .. ":call_id:" .. item.call_id
+    end
+    local ok, encoded = pcall(json.encode, item)
+    return ok and (item_type .. ":json:" .. encoded) or nil
+end
+
+local function mergeResponsesOutput(completed_items, terminal_items)
+    local merged = {}
+    local seen = {}
+    local function keySeen(item)
+        local key = responsesOutputItemKey(item)
+        return key, key and seen[key] == true
+    end
+    local function mark(item, key)
+        if key then seen[key] = true end
+        return item
+    end
+
+    for _, item in ipairs(terminal_items or {}) do
+        if type(item) == "table" then
+            local key, duplicate = keySeen(item)
+            if not duplicate then merged[#merged + 1] = mark(item, key) end
+        end
+    end
+
+    table.sort(completed_items, function(a, b)
+        local ai = type(a.output_index) == "number" and a.output_index or math.huge
+        local bi = type(b.output_index) == "number" and b.output_index or math.huge
+        if ai == bi then return a.sequence < b.sequence end
+        return ai < bi
+    end)
+    for _, completed in ipairs(completed_items) do
+        local item = completed.item
+        if type(item) == "table" then
+            local key, duplicate = keySeen(item)
+            if not duplicate then
+                local pos = type(completed.output_index) == "number"
+                    and math.max(1, math.min(#merged + 1, completed.output_index + 1))
+                    or (#merged + 1)
+                table.insert(merged, pos, mark(item, key))
+            end
+        end
+    end
+    return merged
+end
+
+local function normalizeResponsesStreamError(err)
+    if type(err) == "table" then return err end
+    return { message = tostring(err or "Unknown streaming error") }
+end
+
+function ResponseParser.collectResponsesSSE(body)
+    local output = {}
+    local terminal
+    local stream_error
+
+    for line in (tostring(body or "") .. "\n"):gmatch("([^\n]*)\n") do
+        line = line:gsub("\r$", "")
+        local data = line:match("^data:%s*(.*)$")
+        if data and data ~= "" and data ~= "[DONE]" then
+            local ok, event = pcall(json.decode, data)
+            if ok and type(event) == "table" then
+                if event.type == "response.output_item.done" and type(event.item) == "table" then
+                    output[#output + 1] = {
+                        item = event.item,
+                        output_index = event.output_index,
+                        sequence = #output + 1,
+                    }
+                elseif (event.type == "response.completed" or event.type == "response.incomplete")
+                        and type(event.response) == "table" then
+                    terminal = event.response
+                elseif event.type == "response.failed" then
+                    terminal = type(event.response) == "table" and event.response or terminal
+                    stream_error = event.error or (terminal and terminal.error)
+                elseif event.type == "error" then
+                    stream_error = event.error or event
+                end
+            end
+        end
+    end
+
+    if not terminal then
+        if stream_error then
+            terminal = {
+                status = "failed",
+                error = normalizeResponsesStreamError(stream_error),
+                output = {},
+            }
+        else
+            error("Responses SSE ended without a terminal response event")
+        end
+    end
+    terminal.output = mergeResponsesOutput(output, terminal.output)
+    if stream_error and not terminal.error then
+        terminal.error = normalizeResponsesStreamError(stream_error)
+    end
+    return json.encode(terminal)
+end
+
 -- Response format transformers for each provider
 -- Returns: success, content, reasoning (reasoning is optional third return value)
 local RESPONSE_TRANSFORMERS = {

--- a/koassistant_api/response_parser.lua
+++ b/koassistant_api/response_parser.lua
@@ -174,8 +174,11 @@ local function mergeResponsesOutput(completed_items, terminal_items)
 end
 
 local function normalizeResponsesStreamError(err)
+    -- KOReader's json decodes JSON null to a truthy non-table sentinel; only
+    -- tables and strings carry real error information.
     if type(err) == "table" then return err end
-    return { message = tostring(err or "Unknown streaming error") }
+    if type(err) == "string" and err ~= "" then return { message = err } end
+    return { message = "Unknown streaming error" }
 end
 
 function ResponseParser.collectResponsesSSE(body)
@@ -183,8 +186,9 @@ function ResponseParser.collectResponsesSSE(body)
     local terminal
     local stream_error
 
-    for line in (tostring(body or "") .. "\n"):gmatch("([^\n]*)\n") do
-        line = line:gsub("\r$", "")
+    -- raw_line stays untouched: generic-for variables are const in Lua 5.4+.
+    for raw_line in (tostring(body or "") .. "\n"):gmatch("([^\n]*)\n") do
+        local line = raw_line:gsub("\r$", "")
         local data = line:match("^data:%s*(.*)$")
         if data and data ~= "" and data ~= "[DONE]" then
             local ok, event = pcall(json.decode, data)

--- a/koassistant_api/tool_wire.lua
+++ b/koassistant_api/tool_wire.lua
@@ -173,6 +173,10 @@ ToolWire.adapters.openai = {
 -- OpenRouter speaks the OpenAI tool wire format verbatim (it normalizes across backends).
 ToolWire.adapters.openrouter = ToolWire.adapters.openai
 
+-- OpenAI Subscription uses the Responses wire through the Codex backend. The
+-- handler adapts its mandatory SSE transport for non-streamed gather turns.
+ToolWire.adapters.openai_codex = ToolWire.adapters.openai
+
 -- Tools wave 1 (web_search_tool_plan.md rollout): these providers speak the OpenAI
 -- chat-completions tool wire verbatim. Each also has a `tools` capability list in
 -- model_constraints.lua (the load-bearing gate — some backends silently ignore the

--- a/koassistant_backup_manager.lua
+++ b/koassistant_backup_manager.lua
@@ -369,7 +369,13 @@ function BackupManager:_extractArchive(archive_path, dest_dir, specific_file)
     -- specific_file: optional, extract only this file (e.g., "manifest.json")
     local cmd
     if specific_file then
-        cmd = string.format('tar -xzf "%s" -C "%s" "%s" 2>&1', safe_archive, safe_dest, specific_file)
+        -- Archives created with `tar ... .` store entries as `./name` on GNU
+        -- tar, while older/platform archives may store `name`. Accept both.
+        cmd = string.format(
+            'tar -xzf "%s" -C "%s" "%s" 2>/dev/null || tar -xzf "%s" -C "%s" "./%s" 2>&1',
+            safe_archive, safe_dest, specific_file,
+            safe_archive, safe_dest, specific_file
+        )
     else
         cmd = string.format('tar -xzf "%s" -C "%s"', safe_archive, safe_dest)
     end
@@ -881,11 +887,10 @@ function BackupManager:createBackup(options)
                 local settings = LuaSettings:open(settings_file)
                 local features = settings:readSetting("features") or {}
 
-                -- Save API keys for later restoration
-                local api_keys = features.api_keys
-
-                -- Remove API keys temporarily
+                -- OAuth subscription tokens are credentials and follow the same
+                -- include/exclude switch as API keys.
                 features.api_keys = nil
+                features.openai_codex_oauth = nil
 
                 -- Save modified settings to temp location
                 local temp_settings = LuaSettings:open(settings_dir .. "/koassistant_settings.lua")
@@ -1443,7 +1448,7 @@ function BackupManager:restoreBackup(backup_path, options)
                 local current_features = current_settings:readSetting("features") or {}
                 local backup_features = backup_settings:readSetting("features") or {}
 
-                -- Merge API keys if requested
+                -- Merge API keys and subscription OAuth credentials if requested
                 if options.restore_api_keys and manifest.contents.api_keys then
                     if backup_features.api_keys then
                         current_features.api_keys = current_features.api_keys or {}
@@ -1451,11 +1456,15 @@ function BackupManager:restoreBackup(backup_path, options)
                             current_features.api_keys[provider] = key
                         end
                     end
+                    if backup_features.openai_codex_oauth then
+                        current_features.openai_codex_oauth = backup_features.openai_codex_oauth
+                    end
                 end
 
                 -- Merge other features (backup takes precedence)
                 for key, value in pairs(backup_features) do
-                    if key ~= "api_keys" or (options.restore_api_keys and manifest.contents.api_keys) then
+                    local credential = key == "api_keys" or key == "openai_codex_oauth"
+                    if not credential or (options.restore_api_keys and manifest.contents.api_keys) then
                         current_features[key] = value
                     end
                 end
@@ -1500,6 +1509,12 @@ function BackupManager:restoreBackup(backup_path, options)
                 -- Replace mode: replace entire settings file with validation
                 local backup_settings = LuaSettings:open(backup_settings_file)
                 local backup_features = backup_settings:readSetting("features") or {}
+
+                -- Never restore credentials unless the user explicitly requested it.
+                if not options.restore_api_keys or not manifest.contents.api_keys then
+                    backup_features.api_keys = nil
+                    backup_features.openai_codex_oauth = nil
+                end
 
                 -- Validate custom actions in features
                 if backup_features.custom_actions then

--- a/koassistant_dialogs.lua
+++ b/koassistant_dialogs.lua
@@ -794,7 +794,10 @@ local function pickProviderModel(opts)
         end
         local all_providers = {}
         for _idx, provider in ipairs(ModelLists.getAllProviders()) do
-            table.insert(all_providers, { id = provider, name = provider:gsub("^%l", string.upper) })
+            local name = plugin and plugin.getProviderDisplayName
+                and plugin:getProviderDisplayName(provider)
+                or provider:gsub("^%l", string.upper)
+            table.insert(all_providers, { id = provider, name = name })
         end
         if plugin and plugin.getCustomProviders then
             for _idx, cp in ipairs(plugin:getCustomProviders()) do

--- a/koassistant_gpt_query.lua
+++ b/koassistant_gpt_query.lua
@@ -45,6 +45,7 @@ end
 
 loadHandler("anthropic")
 loadHandler("openai")
+loadHandler("openai_codex")
 loadHandler("deepseek")
 loadHandler("ollama")
 loadHandler("gemini")
@@ -393,19 +394,32 @@ local function queryChatGPT(message_history, temp_config, on_complete, settings)
         return "Error: " .. err
     end
 
-    -- Get API key for the selected provider (GUI settings take priority over apikeys.lua)
-    config.api_key = getApiKey(provider, settings)
+    -- Get API key for ordinary providers. OpenAI Subscription stores OAuth
+    -- credentials separately and resolves/refreshes them only after WiFi is ready.
+    if provider ~= "openai_codex" then
+        config.api_key = getApiKey(provider, settings)
+    end
 
     -- Check if API key is required
     local api_key_required = true
-    if provider == "ollama" then
+    if provider == "ollama" or provider == "openai_codex" then
         api_key_required = false
     elseif is_custom_provider and custom_provider_config then
         -- Custom providers can optionally not require an API key (for local servers)
         api_key_required = custom_provider_config.api_key_required ~= false
     end
 
-    if not config.api_key and api_key_required then
+    if provider == "openai_codex" then
+        local OAuth = require("koassistant_openai_codex_oauth")
+        if not settings or not OAuth.isConfigured(settings) then
+            local err = "OpenAI Subscription is not connected. Connect it in Settings → API Keys."
+            if on_complete then
+                on_complete(false, nil, err)
+                return STREAMING_IN_PROGRESS
+            end
+            return "Error: " .. err
+        end
+    elseif not config.api_key and api_key_required then
         local err = string.format("No API key found for provider %s. Set it in Settings → API Keys or apikeys.lua", provider)
         if on_complete then
             on_complete(false, nil, err)
@@ -419,7 +433,7 @@ local function queryChatGPT(message_history, temp_config, on_complete, settings)
     -- When WiFi is off, shows the WiFi turn-on dialog and runs the callback after connection.
     local NetworkMgr = require("ui/network/manager")
     local query_return = STREAMING_IN_PROGRESS
-    local function doQuery()
+    local function doQueryWithAuth()
 
     local success, result = pcall(function()
         return handler:query(message_history, config)
@@ -574,7 +588,25 @@ local function queryChatGPT(message_history, temp_config, on_complete, settings)
     end
     query_return = result
 
-    end -- doQuery
+    end -- doQueryWithAuth
+
+    local function doQuery()
+        if provider ~= "openai_codex" then
+            return doQueryWithAuth()
+        end
+        require("koassistant_openai_codex_oauth").resolveAccessTokenAsync(settings, function(auth, oauth_err)
+            if not auth then
+                local err = oauth_err or "OpenAI Subscription authentication failed."
+                if on_complete then on_complete(false, nil, err) end
+                query_return = "Error: " .. err
+                return
+            end
+            config.api_key = auth.access_token
+            config.oauth = auth
+            doQueryWithAuth()
+        end)
+        return STREAMING_IN_PROGRESS
+    end
 
     -- Background requests never prompt (update-checker precedent): the auto-update
     -- fire pre-checked isWifiOn(), and a drop inside the schedule window should fail

--- a/koassistant_model_lists.lua
+++ b/koassistant_model_lists.lua
@@ -40,6 +40,19 @@ local ModelLists = {
         -- NOTE: *-pro variants are v1/responses only (not chat-completions) — excluded.
     },
 
+    openai_codex = {
+        -- OpenAI ChatGPT subscription (Codex OAuth) reuses the same curated
+        -- subscription model slugs as direct OpenAI, but authenticates with
+        -- device-code OAuth against ChatGPT's Codex backend.
+        "gpt-5.6-terra",                -- balanced (default)
+        "gpt-5.6-sol",                  -- flagship (most capable)
+        "gpt-5.6-luna",                 -- cost-optimized
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+    },
+
     deepseek = {
         -- DeepSeek V4 (current generation, 1M context, thinking on by default)
         "deepseek-v4-pro",              -- flagship (default) + reasoning
@@ -338,6 +351,7 @@ local ModelLists = {
     _shipped_defaults = {
         anthropic  = { "claude-sonnet-5", "claude-sonnet-4-6", "claude-sonnet-4-5-20250929" },
         openai     = { "gpt-5.6-terra", "gpt-5.5", "gpt-5.4", "gpt-5.2" },
+        openai_codex = { "gpt-5.6-terra", "gpt-5.5", "gpt-5.4" },
         gemini     = { "gemini-3.6-flash", "gemini-3.5-flash", "gemini-2.5-flash", "gemini-3-flash-preview" },
         deepseek   = { "deepseek-v4-pro", "deepseek-chat" },
         ollama     = { "llama4", "llama3.3" },
@@ -374,6 +388,7 @@ local ModelLists = {
         flagship = {
             anthropic = "claude-sonnet-5",
             openai = "gpt-5.6-sol",
+            openai_codex = "gpt-5.6-sol",
             deepseek = "deepseek-v4-pro",
             gemini = "gemini-3.6-flash",             -- Pro models are paid-only; keep tier free-tier usable (3.6 flash assumed free-tier)
             groq = "llama-3.3-70b-versatile",
@@ -397,6 +412,7 @@ local ModelLists = {
         standard = {
             anthropic = "claude-sonnet-5",
             openai = "gpt-5.6-terra",  -- standard/default
+            openai_codex = "gpt-5.6-terra",
             deepseek = "deepseek-v4-flash",
             gemini = "gemini-3.6-flash",
             groq = "llama-3.3-70b-versatile",
@@ -420,6 +436,7 @@ local ModelLists = {
         fast = {
             anthropic = "claude-haiku-4-5-20251001",
             openai = "gpt-5.6-luna",
+            openai_codex = "gpt-5.6-luna",
             deepseek = "deepseek-v4-flash",
             gemini = "gemini-3.6-flash",
             groq = "llama-3.1-8b-instant",
@@ -443,6 +460,7 @@ local ModelLists = {
         ultrafast = {
             anthropic = "claude-haiku-4-5-20251001",
             openai = "gpt-5.4-nano",
+            openai_codex = "gpt-5.4-nano",
             deepseek = "deepseek-v4-flash",
             gemini = "gemini-3.5-flash-lite",
             groq = "llama-3.1-8b-instant",
@@ -480,7 +498,10 @@ local ModelLists = {
         openai = {
             api_list = "https://api.openai.com/v1/models",
             docs = "https://platform.openai.com/docs/models",
-            curl = "curl https://api.openai.com/v1/models -H 'Authorization: Bearer $OPENAI_API_KEY'",
+            curl = "curl https://api.openai.com/v1/models -H 'Authorization: Bearer ***'",
+        },
+        openai_codex = {
+            docs = "https://auth.openai.com/codex/device",
         },
         deepseek = {
             api_list = "https://api.deepseek.com/v1/models",

--- a/koassistant_openai_codex_oauth.lua
+++ b/koassistant_openai_codex_oauth.lua
@@ -1,0 +1,639 @@
+local json = require("json")
+local ffi = require("ffi")
+local ffiutil = require("ffi/util")
+local BaseHandler = require("koassistant_api.base")
+local _ = require("koassistant_gettext")
+
+local OAuth = {}
+local unpackValues = table.unpack or unpack
+
+OAuth.CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+OAuth.SETTINGS_KEY = "openai_codex_oauth"
+OAuth.USER_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode"
+OAuth.DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token"
+OAuth.OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+OAuth.REDIRECT_URI = "https://auth.openai.com/deviceauth/callback"
+OAuth.VERIFICATION_URL = "https://auth.openai.com/codex/device"
+OAuth.REFRESH_SKEW_SECONDS = 300
+OAuth.FLOW_TIMEOUT_SECONDS = 15 * 60
+
+local AUTH_CLAIM = "https://api.openai.com/auth"
+
+local function str(value)
+    return type(value) == "string" and value ~= "" and value or nil
+end
+
+local function number(value)
+    if type(value) == "number" then return value end
+    if type(value) == "string" then return tonumber(value) end
+    return nil
+end
+
+local function urlEncode(value)
+    return (tostring(value or ""):gsub("([^%w%-%._~])", function(char)
+        return string.format("%%%02X", string.byte(char))
+    end))
+end
+
+local FORM_ORDER = { "grant_type", "client_id", "code", "redirect_uri", "code_verifier", "refresh_token" }
+local function formEncode(values)
+    local parts = {}
+    for _, key in ipairs(FORM_ORDER) do
+        if values[key] ~= nil then
+            parts[#parts + 1] = urlEncode(key) .. "=" .. urlEncode(values[key])
+        end
+    end
+    return table.concat(parts, "&")
+end
+
+local function b64urlDecode(segment)
+    if not str(segment) then return nil end
+    local encoded = segment:gsub("-", "+"):gsub("_", "/")
+    local remainder = #encoded % 4
+    if remainder == 2 then encoded = encoded .. "=="
+    elseif remainder == 3 then encoded = encoded .. "="
+    elseif remainder == 1 then return nil end
+
+    local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    if encoded:find("[^A-Za-z0-9+/=]") then return nil end
+    local bits = encoded:gsub(".", function(char)
+        if char == "=" then return "" end
+        local value = (alphabet:find(char, 1, true) or 1) - 1
+        local out = ""
+        for i = 6, 1, -1 do
+            out = out .. ((value % 2^i - value % 2^(i - 1) > 0) and "1" or "0")
+        end
+        return out
+    end)
+    return bits:gsub("%d%d%d?%d?%d?%d?%d?%d?", function(byte)
+        if #byte ~= 8 then return "" end
+        local value = 0
+        for i = 1, 8 do
+            if byte:sub(i, i) == "1" then value = value + 2^(8 - i) end
+        end
+        return string.char(value)
+    end)
+end
+
+function OAuth.parseJwtPayload(token)
+    if type(token) ~= "string" then return nil end
+    local payload_segment = token:match("^[^.]+%.([^.]+)%.[^.]+$")
+    if not payload_segment then return nil end
+    local raw = b64urlDecode(payload_segment)
+    local ok, payload = pcall(json.decode, raw or "")
+    if not ok or type(payload) ~= "table" then return nil end
+    local auth = type(payload[AUTH_CLAIM]) == "table" and payload[AUTH_CLAIM] or {}
+    return {
+        exp = number(payload.exp),
+        chatgpt_account_id = str(auth.chatgpt_account_id),
+        raw = payload,
+    }
+end
+
+function OAuth.normalizeTokenSet(token_set, fallback_refresh_token, now)
+    if type(token_set) ~= "table" then return nil end
+    now = now or os.time()
+    local normalized = {
+        access_token = str(token_set.access_token),
+        refresh_token = str(token_set.refresh_token) or str(fallback_refresh_token),
+        token_type = str(token_set.token_type) or "Bearer",
+        scope = str(token_set.scope),
+        updated_at = now,
+    }
+    local payload = OAuth.parseJwtPayload(normalized.access_token)
+    normalized.expires_at = payload and payload.exp
+        or number(token_set.expires_at)
+        or (number(token_set.expires_in) and now + number(token_set.expires_in))
+    normalized.chatgpt_account_id = payload and payload.chatgpt_account_id
+        or str(token_set.chatgpt_account_id)
+    return normalized
+end
+
+function OAuth.shouldRefresh(auth, now, skew)
+    now = now or os.time()
+    skew = skew or OAuth.REFRESH_SKEW_SECONDS
+    if type(auth) ~= "table" or not str(auth.access_token) then return true end
+    local expires_at = number(auth.expires_at)
+    return not expires_at or expires_at <= now + skew
+end
+
+local function jsonRequest(url, body)
+    return {
+        url = url,
+        method = "POST",
+        headers = { ["Content-Type"] = "application/json" },
+        body = json.encode(body),
+    }
+end
+
+function OAuth.buildUserCodeRequest()
+    return jsonRequest(OAuth.USER_CODE_URL, { client_id = OAuth.CLIENT_ID })
+end
+
+function OAuth.buildPollRequest(device_auth_id, user_code)
+    return jsonRequest(OAuth.DEVICE_TOKEN_URL, {
+        device_auth_id = device_auth_id,
+        user_code = user_code,
+    })
+end
+
+function OAuth.buildTokenExchangeRequest(authorization_code, code_verifier)
+    return {
+        url = OAuth.OAUTH_TOKEN_URL,
+        method = "POST",
+        headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+        body = formEncode({
+            grant_type = "authorization_code",
+            client_id = OAuth.CLIENT_ID,
+            code = authorization_code,
+            redirect_uri = OAuth.REDIRECT_URI,
+            code_verifier = code_verifier,
+        }),
+    }
+end
+
+function OAuth.buildRefreshRequest(refresh_token)
+    return {
+        url = OAuth.OAUTH_TOKEN_URL,
+        method = "POST",
+        headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+        body = formEncode({
+            grant_type = "refresh_token",
+            client_id = OAuth.CLIENT_ID,
+            refresh_token = refresh_token,
+        }),
+    }
+end
+
+local function decodeBody(body)
+    if not str(body) then return nil end
+    local ok, decoded = pcall(json.decode, body)
+    return ok and type(decoded) == "table" and decoded or nil
+end
+
+local function errorMessage(status_code, body)
+    local decoded = decodeBody(body)
+    if decoded then
+        if type(decoded.error) == "table" and str(decoded.error.message) then return decoded.error.message end
+        if str(decoded.error_description) then return decoded.error_description end
+        if str(decoded.error) then return decoded.error end
+        if str(decoded.message) then return decoded.message end
+    end
+    -- Do not surface raw OAuth bodies: token endpoints can contain credential
+    -- material and UI errors may be captured in screenshots or logs.
+    return string.format("HTTP %s", tostring(status_code))
+end
+
+function OAuth.classifyPollResponse(status_code, body)
+    if status_code == 403 or status_code == 404 then return { status = "pending" } end
+    if status_code == 429 then return { status = "slow_down" } end
+    local decoded = decodeBody(body)
+    if status_code == 200 and decoded then
+        local authorization_code = str(decoded.authorization_code)
+        local code_verifier = str(decoded.code_verifier)
+        if authorization_code and code_verifier then
+            return {
+                status = "authorized",
+                authorization_code = authorization_code,
+                code_verifier = code_verifier,
+            }
+        end
+    end
+    return { status = "error", error = errorMessage(status_code, body) }
+end
+
+local function httpRequestSync(request)
+    local headers = {}
+    for key, value in pairs(request.headers or {}) do headers[key] = value end
+    if request.body then headers["Content-Length"] = tostring(#request.body) end
+    return BaseHandler.fetchInSubprocess(request.url, {
+        method = request.method,
+        headers = headers,
+        body = request.body,
+        resolved_ip = request.resolved_ip or BaseHandler.resolveForSubprocess(request.url),
+        timeout = request.timeout or 30,
+    })
+end
+
+
+function OAuth.readAuth(settings)
+    if not settings then return nil end
+    local features = settings:readSetting("features") or {}
+    return type(features[OAuth.SETTINGS_KEY]) == "table" and features[OAuth.SETTINGS_KEY] or nil
+end
+
+function OAuth.saveAuth(settings, auth)
+    if not settings or type(auth) ~= "table" then return false end
+    local features = settings:readSetting("features") or {}
+    features[OAuth.SETTINGS_KEY] = auth
+    settings:saveSetting("features", features)
+    settings:flush()
+    return true
+end
+
+function OAuth.clearAuth(settings)
+    if not settings then return false end
+    local features = settings:readSetting("features") or {}
+    features[OAuth.SETTINGS_KEY] = nil
+    settings:saveSetting("features", features)
+    settings:flush()
+    return true
+end
+
+function OAuth.isConfigured(settings)
+    local auth = OAuth.readAuth(settings)
+    return type(auth) == "table" and str(auth.refresh_token) ~= nil
+        and str(auth.chatgpt_account_id) ~= nil
+end
+
+
+local function makePipeFetchFn(request)
+    return function(pid, child_write_fd)
+        if not pid or not child_write_fd then return end
+        local ok, status_code, body = pcall(httpRequestSync, request)
+        local payload = ok
+            and json.encode({ status_code = status_code, body = body or "" })
+            or json.encode({ status_code = 0, body = tostring(status_code) })
+        BaseHandler.writeAllToFD(child_write_fd, payload)
+        ffi.C.close(child_write_fd)
+        pcall(function() ffi.C._exit(0) end)
+    end
+end
+
+local function pollSubprocess(pid, read_fd, on_done)
+    local UIManager = require("ui/uimanager")
+    local chunk_size = 65536
+    local buffer = ffi.new("char[?]", chunk_size)
+    local pointer = ffi.cast("void*", buffer)
+    local parts = {}
+
+    local function finish()
+        ffi.C.close(read_fd)
+        on_done(table.concat(parts))
+    end
+
+    local function poll()
+        while true do
+            local available = ffiutil.getNonBlockingReadSize(read_fd) or 0
+            if available > 0 then
+                local bytes = tonumber(ffi.C.read(read_fd, pointer, chunk_size))
+                if bytes and bytes > 0 then parts[#parts + 1] = ffi.string(pointer, bytes)
+                else finish() return end
+            elseif ffiutil.isSubProcessDone(pid) then
+                while true do
+                    local bytes = tonumber(ffi.C.read(read_fd, pointer, chunk_size))
+                    if not bytes or bytes <= 0 then break end
+                    parts[#parts + 1] = ffi.string(pointer, bytes)
+                end
+                finish()
+                return
+            else
+                UIManager:scheduleIn(0.15, poll)
+                return
+            end
+        end
+    end
+    UIManager:scheduleIn(0.15, poll)
+end
+
+local function runAsync(request, on_done)
+    -- DNS/libc resolution is unsafe after fork on macOS. Resolve in the parent,
+    -- matching BaseHandler's subprocess contract.
+    request.resolved_ip = BaseHandler.resolveForSubprocess(request.url)
+    local pid, read_fd = ffiutil.runInSubProcess(makePipeFetchFn(request), true)
+    if not pid then on_done(nil, _("Failed to start OAuth subprocess.")); return nil end
+    pollSubprocess(pid, read_fd, function(raw)
+        local decoded = decodeBody(raw)
+        if not decoded then on_done(nil, _("Failed to parse OAuth subprocess response.")); return end
+        on_done(decoded)
+    end)
+    return pid
+end
+
+local asyncRunner = runAsync
+function OAuth._setAsyncRunnerForTests(runner)
+    asyncRunner = runner or runAsync
+end
+
+function OAuth.resolveAccessTokenAsync(settings, on_done)
+    local auth = OAuth.readAuth(settings)
+    if not auth then
+        on_done(nil, _("OpenAI Subscription is not connected."))
+        return nil
+    end
+    if not OAuth.shouldRefresh(auth) then
+        on_done(auth)
+        return nil
+    end
+
+    local ok, pid_or_err = pcall(function()
+        return asyncRunner(OAuth.buildRefreshRequest(auth.refresh_token), function(result, transport_err)
+            if transport_err then
+                on_done(nil, transport_err)
+                return
+            end
+            if not result or result.status_code ~= 200 then
+                on_done(nil, errorMessage(result and result.status_code, result and result.body))
+                return
+            end
+            local refreshed = OAuth.normalizeTokenSet(decodeBody(result.body), auth.refresh_token)
+            if not (refreshed and refreshed.access_token and refreshed.refresh_token and refreshed.chatgpt_account_id) then
+                on_done(nil, _("Refresh response was incomplete."))
+                return
+            end
+            OAuth.saveAuth(settings, refreshed)
+            on_done(refreshed)
+        end)
+    end)
+    if not ok or not pid_or_err then
+        on_done(nil, ok and _("Failed to start OAuth refresh subprocess.") or tostring(pid_or_err))
+        return nil
+    end
+    return pid_or_err
+end
+
+local function selectProviderIfFirst(plugin)
+    if not (plugin and plugin.settings) then return end
+    local features = plugin.settings:readSetting("features") or {}
+    local Base = require("koassistant_api.base")
+    local ModelLists = require("koassistant_model_lists")
+    local has_key = false
+    for _, provider in ipairs(ModelLists.getAllProviders()) do
+        if provider ~= "openai_codex" and Base.getApiKey(provider, plugin.settings) then
+            has_key = true
+            break
+        end
+    end
+    if not has_key then
+        features.provider = "openai_codex"
+        features.model = nil
+        plugin.settings:saveSetting("features", features)
+        plugin.settings:flush()
+    end
+end
+
+function OAuth.showManageDialog(plugin)
+    local UIManager = require("ui/uimanager")
+    local ButtonDialog = require("ui/widget/buttondialog")
+    local Notification = require("ui/widget/notification")
+    local auth = OAuth.readAuth(plugin and plugin.settings)
+    local connected = OAuth.isConfigured(plugin and plugin.settings)
+    local dialog
+    local buttons = {}
+    buttons[#buttons + 1] = {{
+        text = connected and _("Reconnect") or _("Connect"),
+        callback = function()
+            UIManager:close(dialog)
+            OAuth.startInteractiveConnect(plugin)
+        end,
+    }}
+    if connected then
+        buttons[#buttons + 1] = {{
+            text = _("Disconnect"),
+            callback = function()
+                OAuth.clearAuth(plugin.settings)
+                if plugin.updateConfigFromSettings then plugin:updateConfigFromSettings() end
+                UIManager:close(dialog)
+                UIManager:show(Notification:new{ text = _("OpenAI Subscription disconnected"), timeout = 2 })
+            end,
+        }}
+    end
+    buttons[#buttons + 1] = {{ text = _("Close"), callback = function() UIManager:close(dialog) end }}
+    dialog = ButtonDialog:new{
+        title = connected and _("OpenAI Subscription · Connected") or _("OpenAI Subscription · Not connected"),
+        buttons = buttons,
+    }
+    UIManager:show(dialog)
+end
+
+function OAuth.buildDeviceDialogText(user_code, status_message)
+    local lines = {
+        _("Open this URL on another device:"),
+        OAuth.VERIFICATION_URL,
+        "",
+        _("Enter this code:"),
+        tostring(user_code or ""),
+        "",
+        _("The code expires in 15 minutes."),
+    }
+    if status_message and status_message ~= "" then
+        lines[#lines + 1] = ""
+        lines[#lines + 1] = status_message
+    end
+    return table.concat(lines, "\n")
+end
+
+local function showConnectEntryError(message)
+    local UIManager = require("ui/uimanager")
+    local InfoMessage = require("ui/widget/infomessage")
+    UIManager:show(InfoMessage:new{
+        text = _("OpenAI Subscription connection failed.") .. "\n\n" .. tostring(message),
+        timeout = 5,
+    })
+end
+
+local function startInteractiveConnectOnline(plugin)
+    local UIManager = require("ui/uimanager")
+    local ButtonDialog = require("ui/widget/buttondialog")
+    local Notification = require("ui/widget/notification")
+    local Device = require("device")
+
+    local active_pid
+    local stopped = false
+    local in_flight = false
+    local device
+    local dialog
+
+    local function closeDialog()
+        if dialog then
+            UIManager:close(dialog)
+            dialog = nil
+        end
+    end
+
+    local function cancel()
+        if stopped then return end
+        stopped = true
+        if active_pid then
+            ffiutil.terminateSubProcess(active_pid)
+            active_pid = nil
+        end
+        closeDialog()
+    end
+
+    local function guarded(fn)
+        return function(...)
+            if stopped then return end
+            local args = { ... }
+            local ok, err = xpcall(function() fn(unpackValues(args)) end, debug.traceback)
+            if not ok then
+                cancel()
+                showConnectEntryError(err)
+            end
+        end
+    end
+
+    local function request(req, callback)
+        if stopped or in_flight then return false end
+        in_flight = true
+        local ok, pid_or_err = pcall(function()
+            return asyncRunner(req, guarded(function(result, err)
+                active_pid = nil
+                in_flight = false
+                if err then
+                    cancel()
+                    showConnectEntryError(err)
+                else
+                    callback(result)
+                end
+            end))
+        end)
+        if not ok or not pid_or_err then
+            in_flight = false
+            cancel()
+            showConnectEntryError(ok and _("Failed to start OAuth subprocess.") or pid_or_err)
+            return false
+        end
+        active_pid = pid_or_err
+        return true
+    end
+
+    local showDeviceDialog
+    local function showStatus(message)
+        if stopped then return end
+        if dialog and dialog.setTitle and device then
+            dialog:setTitle(OAuth.buildDeviceDialogText(device.user_code, message))
+        else
+            closeDialog()
+            showDeviceDialog(message)
+        end
+    end
+
+    local function exchange(state)
+        showStatus(_("Authorization received. Connecting…"))
+        request(OAuth.buildTokenExchangeRequest(state.authorization_code, state.code_verifier), function(exchange_result)
+            if exchange_result.status_code ~= 200 then
+                showStatus(errorMessage(exchange_result.status_code, exchange_result.body))
+                return
+            end
+            local auth = OAuth.normalizeTokenSet(decodeBody(exchange_result.body))
+            if not (auth and auth.access_token and auth.refresh_token and auth.chatgpt_account_id) then
+                showStatus(_("OpenAI Subscription connection returned incomplete tokens."))
+                return
+            end
+            OAuth.saveAuth(plugin.settings, auth)
+            selectProviderIfFirst(plugin)
+            if plugin.updateConfigFromSettings then plugin:updateConfigFromSettings() end
+            stopped = true
+            closeDialog()
+            UIManager:show(Notification:new{ text = _("OpenAI Subscription connected"), timeout = 3 })
+        end)
+    end
+
+    local function checkAuthorization()
+        if stopped or in_flight or not device then return end
+        if os.time() >= device.expires_at then
+            showStatus(_("This device code has expired. Cancel and connect again."))
+            return
+        end
+        showStatus(_("Checking authorization…"))
+        request(OAuth.buildPollRequest(device.device_auth_id, device.user_code), function(result)
+            local state = OAuth.classifyPollResponse(result.status_code, result.body)
+            if state.status == "pending" then
+                showStatus(_("Not authorized yet. Complete the browser steps, then check again."))
+            elseif state.status == "slow_down" then
+                showStatus(_("Please wait a few seconds before checking again."))
+            elseif state.status == "authorized" then
+                exchange(state)
+            else
+                showStatus(state.error or _("Authorization check failed."))
+            end
+        end)
+    end
+
+    showDeviceDialog = function(status_message)
+        if stopped or not device then return end
+        local buttons = {
+            {
+                {
+                    text = _("Copy code"),
+                    callback = guarded(function()
+                        if Device and Device.input and Device.input.setClipboardText then
+                            Device.input.setClipboardText(device.user_code)
+                            UIManager:show(Notification:new{ text = _("Device code copied"), timeout = 2 })
+                        else
+                            UIManager:show(Notification:new{ text = _("Clipboard is not available on this device."), timeout = 2 })
+                        end
+                    end),
+                },
+                {
+                    text = _("Check authorization"),
+                    callback = guarded(checkAuthorization),
+                },
+            },
+            {
+                {
+                    text = _("Cancel"),
+                    callback = cancel,
+                },
+            },
+        }
+        dialog = ButtonDialog:new{
+            title = OAuth.buildDeviceDialogText(device.user_code, status_message),
+            buttons = buttons,
+            -- ButtonDialog has no title-bar close callback. Requiring the explicit
+            -- Cancel button prevents a tap-outside/back dismissal from leaving a
+            -- subprocess alive and later resurrecting the dialog from its callback.
+            dismissable = false,
+        }
+        UIManager:show(dialog)
+    end
+
+    dialog = ButtonDialog:new{
+        title = _("Requesting an OpenAI device code…"),
+        buttons = {{ { text = _("Cancel"), callback = cancel } }},
+        dismissable = false,
+    }
+    UIManager:show(dialog)
+
+    request(OAuth.buildUserCodeRequest(), function(result)
+        if result.status_code ~= 200 then
+            cancel()
+            local message = result.status_code == 404
+                and _("Device-code login is not enabled for this account or workspace.")
+                or errorMessage(result.status_code, result.body)
+            showConnectEntryError(message)
+            return
+        end
+        local payload = decodeBody(result.body)
+        device = payload and {
+            device_auth_id = str(payload.device_auth_id),
+            user_code = str(payload.user_code) or str(payload.usercode),
+            interval = math.max(3, number(payload.interval) or 5),
+            expires_at = os.time() + OAuth.FLOW_TIMEOUT_SECONDS,
+        }
+        if not (device and device.device_auth_id and device.user_code) then
+            cancel()
+            showConnectEntryError(_("Device authorization response was incomplete."))
+            return
+        end
+        closeDialog()
+        showDeviceDialog()
+    end)
+end
+
+function OAuth.startInteractiveConnect(plugin)
+    if not (plugin and plugin.settings) then return end
+    local ok, err = xpcall(function()
+        local NetworkMgr = require("ui/network/manager")
+        NetworkMgr:runWhenConnected(function()
+            local online_ok, online_err = xpcall(function()
+                startInteractiveConnectOnline(plugin)
+            end, debug.traceback)
+            if not online_ok then showConnectEntryError(online_err) end
+        end)
+    end, debug.traceback)
+    if not ok then showConnectEntryError(err) end
+end
+
+return OAuth

--- a/koassistant_openai_codex_oauth.lua
+++ b/koassistant_openai_codex_oauth.lua
@@ -408,6 +408,8 @@ end
 
 function OAuth.buildDeviceDialogText(user_code, status_message)
     local lines = {
+        _("Unofficial integration. It may stop working if OpenAI changes the Codex service."),
+        "",
         _("Open this URL on another device:"),
         OAuth.VERIFICATION_URL,
         "",

--- a/koassistant_storage_registry.lua
+++ b/koassistant_storage_registry.lua
@@ -85,7 +85,7 @@ Registry.UNPREFIXED_GLOBAL_KEYS = {
 --                wipe/uninstall — EXCEPT setup_wizard_completed, which Fresh Start
 --                clears so onboarding re-runs.
 Registry.SETTINGS_SUBKEYS = {
-    credentials = { "api_keys" },
+    credentials = { "api_keys", "openai_codex_oauth" },
     assets = {
         "custom_actions", "custom_prompts",                 -- top-level (see TOPLEVEL_SUBKEYS)
         "custom_behaviors", "custom_domains",

--- a/koassistant_ui/prompts_manager.lua
+++ b/koassistant_ui/prompts_manager.lua
@@ -3057,7 +3057,8 @@ function PromptsManager:showProviderSelector(state, show_all)
         if configured or show_all or state.provider == provider then
             local prefix = (state.provider == provider) and "● " or "○ "
             local model_count = ModelLists[provider] and #ModelLists[provider] or 0
-            local label = prefix .. provider .. " (" .. model_count .. " models)"
+            local display = self.plugin:getProviderDisplayName(provider)
+            local label = prefix .. display .. " (" .. model_count .. " models)"
             if not configured then
                 label = T(_("%1 (no key)"), label)
             end
@@ -3859,7 +3860,8 @@ function PromptsManager:showBuiltinProviderSelector(state, show_all)
         if configured or show_all or state.provider == provider then
             local prefix = (state.provider == provider) and "● " or "○ "
             local model_count = ModelLists[provider] and #ModelLists[provider] or 0
-            local label = prefix .. provider .. " (" .. model_count .. " models)"
+            local display = self.plugin:getProviderDisplayName(provider)
+            local label = prefix .. display .. " (" .. model_count .. " models)"
             if not configured then
                 label = T(_("%1 (no key)"), label)
             end

--- a/main.lua
+++ b/main.lua
@@ -2210,6 +2210,9 @@ function AskGPT:getProviderDisplayName(provider_id)
   if custom then
     return custom.name
   end
+  if provider_id == "openai_codex" then
+    return _("OpenAI Subscription")
+  end
   -- Built-in provider: capitalize first letter
   return provider_id:gsub("^%l", string.upper)
 end
@@ -2232,6 +2235,9 @@ end
 -- api_key_required = false). Mirrors the pre-flight gate in koassistant_gpt_query.
 function AskGPT:isProviderConfigured(provider_id, custom_config)
   if provider_id == "ollama" then return true end
+  if provider_id == "openai_codex" then
+    return require("koassistant_openai_codex_oauth").isConfigured(self.settings)
+  end
   local custom = custom_config or self:getCustomProvider(provider_id)
   if custom and custom.api_key_required == false then return true end
   local BaseHandler = require("koassistant_api.base")
@@ -2242,6 +2248,7 @@ end
 -- key. While false (fresh install), key-filtered pickers stay disarmed and show
 -- the full list; keyless-but-usable providers like Ollama don't count toward this.
 function AskGPT:hasAnyRealApiKey()
+  if require("koassistant_openai_codex_oauth").isConfigured(self.settings) then return true end
   local BaseHandler = require("koassistant_api.base")
   local ModelLists = require("koassistant_model_lists")
   for _idx, provider in ipairs(ModelLists.getAllProviders()) do
@@ -2471,7 +2478,7 @@ function AskGPT:buildProviderMenu(simplified, show_all)
   for _i, provider in ipairs(builtin_providers) do
     table.insert(all_providers, {
       id = provider,
-      display_name = provider:gsub("^%l", string.upper),  -- Capitalize
+      display_name = self:getProviderDisplayName(provider),
       is_custom = false,
     })
   end
@@ -3428,10 +3435,13 @@ function AskGPT:buildApiKeysMenu()
 
   -- Add built-in providers
   for _i, provider in ipairs(builtin_providers) do
-    local has_gui_key = gui_keys[provider] and gui_keys[provider] ~= ""
+    local is_subscription = provider == "openai_codex"
+    local has_gui_key = not is_subscription and gui_keys[provider] and gui_keys[provider] ~= ""
     local has_file_key = hasFileApiKey(provider)
     local status = ""
-    if has_gui_key then
+    if is_subscription and require("koassistant_openai_codex_oauth").isConfigured(self.settings) then
+      status = " [connected]"
+    elseif has_gui_key then
       status = " [set]"
     elseif has_file_key then
       status = " (file)"
@@ -3439,7 +3449,7 @@ function AskGPT:buildApiKeysMenu()
 
     table.insert(all_providers, {
       id = provider,
-      display_name = provider:gsub("^%l", string.upper),
+      display_name = self:getProviderDisplayName(provider),
       status = status,
       is_custom = false,
     })
@@ -3478,7 +3488,11 @@ function AskGPT:buildApiKeysMenu()
       text = text,
       keep_menu_open = true,
       callback = function()
-        self_ref:showApiKeyDialog(prov_copy.id, prov_copy.display_name, prov_copy.api_key_optional)
+        if prov_copy.id == "openai_codex" then
+          require("koassistant_openai_codex_oauth").showManageDialog(self_ref)
+        else
+          self_ref:showApiKeyDialog(prov_copy.id, prov_copy.display_name, prov_copy.api_key_optional)
+        end
       end,
     })
   end
@@ -15431,6 +15445,7 @@ function AskGPT:resetAllCustomizations()
   -- Apply defaults, preserving only API keys
   local new_features = SettingsSchema.applyDefaults(features, {
     "features.api_keys",
+    "features.openai_codex_oauth",
   })
 
   self.settings:saveSetting("features", new_features)
@@ -15645,6 +15660,7 @@ end
 function AskGPT:resetAPIKeys()
   local features = self.settings:readSetting("features") or {}
   features.api_keys = nil
+  features.openai_codex_oauth = nil
   self.settings:saveSetting("features", features)
   self.settings:flush()
   self:updateConfigFromSettings()

--- a/model_constraints.lua
+++ b/model_constraints.lua
@@ -1476,7 +1476,7 @@ function ModelConstraints.applyReasoningParams(provider, api_params, decision)
         end
         -- else (off + default-off, e.g. Opus/Sonnet 4.6): emit nothing (Anthropic reasons
         -- only when `thinking` is present).
-    elseif provider == "openai" then
+    elseif provider == "openai" or provider == "openai_codex" then
         if on then api_params.reasoning = { effort = decision.effort } end
     elseif provider == "gemini" then
         if decision.axis == "budget" then
@@ -1529,5 +1529,11 @@ function ModelConstraints.applyReasoningParams(provider, api_params, decision)
         end
     end
 end
+
+-- OpenAI Subscription uses the same model contracts as the direct OpenAI
+-- provider; only its authentication and endpoint differ.
+ModelConstraints.openai_codex = ModelConstraints.openai
+ModelConstraints.capabilities.openai_codex = ModelConstraints.capabilities.openai
+ModelConstraints.reasoning_profiles.openai_codex = ModelConstraints.reasoning_profiles.openai
 
 return ModelConstraints

--- a/model_constraints.lua
+++ b/model_constraints.lua
@@ -695,8 +695,9 @@ ModelConstraints.reasoning_profiles = {
 --   mode = "capability:<name>"    -> only models with that capability (e.g. Gemini's google_search)
 -- Mechanisms today: anthropic (web_search_20250305 tool), openrouter (:online / Exa),
 -- perplexity (built-in Sonar, always on), gemini (googleSearch grounding, capable models),
--- openai + xai (web_search tool on their Responses APIs — the handlers route web-on
--- requests to /v1/responses, responses_api_plan.md), zai (web_search tool on the chat
+-- OpenAI, OpenAI Subscription, and xAI use the web_search tool on their Responses
+-- APIs (the handlers route web-on requests to their Responses endpoints; see
+-- responses_api_plan.md), zai uses a web_search tool on the chat
 -- wire — server-side search, results array echoed back; verified live 2026-07-25 on
 -- glm-5.2 + glm-4.7-flash). Everything else has NO web search via the Chat Completions
 -- API the plugin uses (probed 2026-07-25: deepseek rejects the tool type outright,
@@ -705,6 +706,7 @@ ModelConstraints._web_search_providers = {
     { id = "anthropic",  label = "Anthropic",  mode = "all" },
     { id = "gemini",     label = "Gemini",     mode = "capability:google_search" },
     { id = "openai",     label = "OpenAI",     mode = "capability:responses_web_search" },
+    { id = "openai_codex", label = "OpenAI Subscription", mode = "capability:responses_web_search" },
     { id = "xai",        label = "xAI",        mode = "capability:responses_web_search" },
     { id = "perplexity", label = "Perplexity", mode = "all" },
     { id = "openrouter", label = "OpenRouter", mode = "all" },

--- a/tests/unit/test_backup_roundtrip.lua
+++ b/tests/unit/test_backup_roundtrip.lua
@@ -156,7 +156,7 @@ local function freshManager()
 end
 
 -- Seed a realistic plugin state under the temp dir.
-local SETTINGS_BODY = 'return {\n  ["features"] = { ["api_keys"] = { ["anthropic"] = "sk-secret" } },\n  ["provider"] = "anthropic",\n}\n'
+local SETTINGS_BODY = 'return {\n  ["features"] = { ["api_keys"] = { ["anthropic"] = "sk-secret" }, ["openai_codex_oauth"] = { ["access_token"] = "oauth-access", ["refresh_token"] = "oauth-refresh", ["chatgpt_account_id"] = "acct-test" } },\n  ["provider"] = "anthropic",\n}\n'
 local CONFIG_BODY = '-- user config\nreturn { provider = "openai" }\n'
 local DOMAIN_BODY = '# Academic\nA custom domain.\n'
 local BEHAVIOR_BODY = '# Terse\nBe brief.\n'
@@ -222,6 +222,25 @@ TestRunner:test("listBackups sees the new backup", function()
     TestRunner:assertTrue(found, "listBackups should include the created backup")
 end)
 
+TestRunner:test("ordinary backup excludes API keys and subscription OAuth tokens", function()
+    local sanitized = bm:createBackup({
+        include_settings = true,
+        include_api_keys = false,
+        include_configs = false,
+        include_content = false,
+        include_chats = false,
+    })
+    TestRunner:assertTrue(sanitized and sanitized.success, "sanitized backup should succeed")
+    local check = TMP .. "/check_sanitized"
+    mkdirs(check)
+    TestRunner:assertTrue(sh(string.format('tar -xzf "%s" -C "%s"', sanitized.backup_path, check)),
+        "sanitized archive should extract")
+    local settings = LuaSettingsStub:open(check .. "/settings/koassistant_settings.lua")
+    local features = settings:readSetting("features") or {}
+    TestRunner:assertTrue(features.api_keys == nil, "API keys excluded")
+    TestRunner:assertTrue(features.openai_codex_oauth == nil, "OAuth tokens excluded")
+end)
+
 wipeTmp()
 
 --------------------------------------------------------------------------------
@@ -275,6 +294,9 @@ TestRunner:test("settings (incl. API keys) come back semantically", function()
     local features = s:readSetting("features") or {}
     TestRunner:assertTrue(features.api_keys and features.api_keys.anthropic == "sk-secret",
         "API key should restore (include_api_keys was on)")
+    TestRunner:assertTrue(features.openai_codex_oauth
+        and features.openai_codex_oauth.refresh_token == "oauth-refresh",
+        "subscription OAuth tokens should restore only with credentials")
 end)
 
 wipeTmp()

--- a/tests/unit/test_openai_codex_handler.lua
+++ b/tests/unit/test_openai_codex_handler.lua
@@ -1,0 +1,93 @@
+local function setupPaths()
+    local info = debug.getinfo(1, "S")
+    local script_path = info.source:match("@?(.*)")
+    local unit_dir = script_path:match("(.+)/[^/]+$") or "."
+    local tests_dir = unit_dir:match("(.+)/[^/]+$") or "."
+    local plugin_dir = tests_dir:match("(.+)/[^/]+$") or "."
+
+    package.path = table.concat({
+        plugin_dir .. "/?.lua",
+        tests_dir .. "/?.lua",
+        tests_dir .. "/lib/?.lua",
+        package.path,
+    }, ";")
+end
+
+setupPaths()
+require("mock_koreader")
+
+local Handler = require("koassistant_api.openai_codex")
+local TestRunner = require("test_runner"):new()
+
+print("")
+print(string.rep("=", 50))
+print("  Unit Tests: OpenAI Codex Handler")
+print(string.rep("=", 50))
+
+local SPECS = {
+    {
+        name = "search_book",
+        description = "Search book text.",
+        parameters = { type = "object", properties = { query = { type = "string" } } },
+    },
+}
+
+local function config(overrides)
+    local c = {
+        model = "gpt-5.6-terra",
+        api_key = "access_token_123",
+        system = { text = "You are helpful." },
+        oauth = { chatgpt_account_id = "acct_123" },
+        features = { enable_streaming = false },
+    }
+    for k, v in pairs(overrides or {}) do c[k] = v end
+    return c
+end
+
+TestRunner:test("buildRequestBody targets ChatGPT codex responses endpoint", function()
+    local result = Handler:buildRequestBody({ { role = "user", content = "hello" } }, config())
+    TestRunner:assertEqual(result.url, "https://chatgpt.com/backend-api/codex/responses", "codex URL")
+    TestRunner:assertEqual(result.provider, "openai_codex", "provider id")
+    TestRunner:assertEqual(result.parser, "openai_responses", "responses parser")
+    TestRunner:assertEqual(result.body.store, false, "stateless request")
+    TestRunner:assertEqual(result.body.max_output_tokens, nil, "Codex backend rejects public max_output_tokens")
+    TestRunner:assertEqual(result.body.instructions, "You are helpful.", "instructions carried")
+end)
+
+TestRunner:test("buildRequestBody uses codex auth headers and account id", function()
+    local result = Handler:buildRequestBody({ { role = "user", content = "hello" } }, config())
+    TestRunner:assertEqual(result.headers["Authorization"], "Bearer access_token_123", "bearer token")
+    TestRunner:assertEqual(result.headers["ChatGPT-Account-ID"], "acct_123", "account header")
+    TestRunner:assertEqual(result.headers["User-Agent"], "codex_cli_rs/0.0.0 (KOAssistant)", "user agent")
+    TestRunner:assertEqual(result.headers["originator"], "codex_cli_rs", "originator header")
+end)
+
+TestRunner:test("buildRequestBody keeps responses tools wire and include for tool turns", function()
+    local result = Handler:buildRequestBody({ { role = "user", content = "hello" } }, config({
+        tools = { specs = SPECS, mode = "ANY" },
+    }))
+    TestRunner:assertEqual(result.body.tools[1].type, "function", "flat function tool")
+    TestRunner:assertEqual(result.body.tools[1].name, "search_book", "tool name")
+    TestRunner:assertEqual(result.body.tool_choice, "required", "ANY => required")
+    TestRunner:assertTrue(result.body.include ~= nil, "reasoning include for stateless replay")
+end)
+
+TestRunner:test("query preserves built custom headers on the background request", function()
+    local captured
+    local original = Handler.backgroundRequest
+    Handler.backgroundRequest = function(self, url, headers, body)
+        captured = { url = url, headers = headers, body = body }
+        return function() end
+    end
+
+    local result = Handler:query({ { role = "user", content = "hello" } }, config())
+    Handler.backgroundRequest = original
+
+    TestRunner:assertTrue(type(result) == "table" and result._background_fn ~= nil, "non-streaming background request returned")
+    TestRunner:assertEqual(captured.url, "https://chatgpt.com/backend-api/codex/responses", "request url")
+    TestRunner:assertEqual(captured.headers["ChatGPT-Account-ID"], "acct_123", "account header forwarded")
+    TestRunner:assertEqual(captured.headers["User-Agent"], "codex_cli_rs/0.0.0 (KOAssistant)", "user agent forwarded")
+    TestRunner:assertEqual(captured.headers["originator"], "codex_cli_rs", "originator forwarded")
+end)
+
+return TestRunner:summary()

--- a/tests/unit/test_openai_codex_handler.lua
+++ b/tests/unit/test_openai_codex_handler.lua
@@ -17,6 +17,8 @@ setupPaths()
 require("mock_koreader")
 
 local Handler = require("koassistant_api.openai_codex")
+local ModelConstraints = require("model_constraints")
+local json = require("json")
 local TestRunner = require("test_runner"):new()
 
 print("")
@@ -58,8 +60,28 @@ TestRunner:test("buildRequestBody uses codex auth headers and account id", funct
     local result = Handler:buildRequestBody({ { role = "user", content = "hello" } }, config())
     TestRunner:assertEqual(result.headers["Authorization"], "Bearer access_token_123", "bearer token")
     TestRunner:assertEqual(result.headers["ChatGPT-Account-ID"], "acct_123", "account header")
-    TestRunner:assertEqual(result.headers["User-Agent"], "codex_cli_rs/0.0.0 (KOAssistant)", "user agent")
-    TestRunner:assertEqual(result.headers["originator"], "codex_cli_rs", "originator header")
+    TestRunner:assertTrue(result.headers["User-Agent"]:find("KOAssistant/", 1, true) == 1, "honest user agent")
+    TestRunner:assertEqual(result.headers["originator"], "koassistant", "honest originator header")
+end)
+
+TestRunner:test("OpenAI Subscription advertises web search support", function()
+    TestRunner:assertTrue(ModelConstraints.supportsWebSearch("openai_codex", "gpt-5.6-terra"), "web search gate")
+end)
+
+TestRunner:test("web-search effort maps to Codex Responses search context", function()
+    local light = config({
+        enable_web_search = true,
+        features = { enable_streaming = true, web_search_effort = "light" },
+    })
+    local thorough = config({
+        enable_web_search = true,
+        features = { enable_streaming = true, web_search_effort = "thorough" },
+    })
+    local light_body = Handler:buildRequestBody({ { role = "user", content = "news" } }, light).body
+    local thorough_body = Handler:buildRequestBody({ { role = "user", content = "news" } }, thorough).body
+    TestRunner:assertEqual(light_body.tools[1].type, "web_search", "hosted web-search tool")
+    TestRunner:assertEqual(light_body.tools[1].search_context_size, "low", "light search")
+    TestRunner:assertEqual(thorough_body.tools[1].search_context_size, "high", "thorough search")
 end)
 
 TestRunner:test("buildRequestBody keeps responses tools wire and include for tool turns", function()
@@ -72,22 +94,54 @@ TestRunner:test("buildRequestBody keeps responses tools wire and include for too
     TestRunner:assertTrue(result.body.include ~= nil, "reasoning include for stateless replay")
 end)
 
-TestRunner:test("query preserves built custom headers on the background request", function()
-    local captured
-    local original = Handler.backgroundRequest
-    Handler.backgroundRequest = function(self, url, headers, body)
-        captured = { url = url, headers = headers, body = body }
-        return function() end
+TestRunner:test("non-streaming query uses collected SSE transport with Codex headers", function()
+    local BaseHandler = require("koassistant_api.base")
+    local original_resolve = BaseHandler.resolveForSubprocess
+    local original_fetch = BaseHandler.fetchInSubprocess
+    local original_write = BaseHandler.writeAllToFD
+    local captured, written
+    BaseHandler.resolveForSubprocess = function() return "203.0.113.10" end
+    BaseHandler.fetchInSubprocess = function(url, opts)
+        captured = { url = url, opts = opts }
+        return 200, 'data: {"type":"response.completed","response":{"status":"completed","output":[]}}\n\n'
     end
+    BaseHandler.writeAllToFD = function(_fd, value) written = value end
 
     local result = Handler:query({ { role = "user", content = "hello" } }, config())
-    Handler.backgroundRequest = original
+    result._background_fn(1, 2)
 
-    TestRunner:assertTrue(type(result) == "table" and result._background_fn ~= nil, "non-streaming background request returned")
+    BaseHandler.resolveForSubprocess = original_resolve
+    BaseHandler.fetchInSubprocess = original_fetch
+    BaseHandler.writeAllToFD = original_write
+
     TestRunner:assertEqual(captured.url, "https://chatgpt.com/backend-api/codex/responses", "request url")
-    TestRunner:assertEqual(captured.headers["ChatGPT-Account-ID"], "acct_123", "account header forwarded")
-    TestRunner:assertEqual(captured.headers["User-Agent"], "codex_cli_rs/0.0.0 (KOAssistant)", "user agent forwarded")
-    TestRunner:assertEqual(captured.headers["originator"], "codex_cli_rs", "originator forwarded")
+    TestRunner:assertEqual(captured.opts.headers["ChatGPT-Account-ID"], "acct_123", "account header forwarded")
+    TestRunner:assertTrue(captured.opts.headers["User-Agent"]:find("KOAssistant/", 1, true) == 1, "user agent forwarded")
+    TestRunner:assertEqual(captured.opts.headers["originator"], "koassistant", "originator forwarded")
+    TestRunner:assertEqual(captured.opts.headers["Accept"], "text/event-stream", "SSE requested")
+    TestRunner:assertEqual(json.decode(captured.opts.body).stream, true, "backend always receives stream=true")
+    TestRunner:assertEqual(json.decode(written).status, "completed", "SSE collected before pipe write")
+end)
+
+TestRunner:test("collected function calls pass through the Responses parser", function()
+    local result = Handler:query({ { role = "user", content = "find whales" } }, config({
+        tools = { specs = SPECS, mode = "ANY" },
+    }))
+
+    local parsed = {
+        status = "completed",
+        output = {{
+            type = "function_call",
+            call_id = "call_1",
+            name = "search_book",
+            arguments = '{"query":"whale"}',
+        }},
+    }
+    local ok, tool_turn = result._response_parser(parsed)
+    TestRunner:assertTrue(ok, "response parsed")
+    TestRunner:assertTrue(tool_turn._tool_calls, "neutral tool-call turn")
+    TestRunner:assertEqual(tool_turn.calls[1].id, "call_1", "call id")
+    TestRunner:assertEqual(tool_turn.calls[1].args.query, "whale", "arguments decoded")
 end)
 
 return TestRunner:summary()

--- a/tests/unit/test_openai_codex_oauth.lua
+++ b/tests/unit/test_openai_codex_oauth.lua
@@ -160,6 +160,8 @@ end)
 
 TestRunner:test("device dialog text displays URL code expiry and status", function()
     local text = OAuth.buildDeviceDialogText("ABCD-EFGH", "Not authorized yet.")
+    TestRunner:assertTrue(text:find("Unofficial integration", 1, true) ~= nil, "unofficial warning")
+    TestRunner:assertTrue(text:find("may stop working", 1, true) ~= nil, "breakage warning")
     TestRunner:assertTrue(text:find("https://auth.openai.com/codex/device", 1, true) ~= nil, "verification URL")
     TestRunner:assertTrue(text:find("ABCD-EFGH", 1, true) ~= nil, "device code")
     TestRunner:assertTrue(text:find("15 minutes", 1, true) ~= nil, "expiry guidance")

--- a/tests/unit/test_openai_codex_oauth.lua
+++ b/tests/unit/test_openai_codex_oauth.lua
@@ -1,0 +1,257 @@
+local function setupPaths()
+    local info = debug.getinfo(1, "S")
+    local script_path = info.source:match("@?(.*)")
+    local unit_dir = script_path:match("(.+)/[^/]+$") or "."
+    local tests_dir = unit_dir:match("(.+)/[^/]+$") or "."
+    local plugin_dir = tests_dir:match("(.+)/[^/]+$") or "."
+    package.path = table.concat({ plugin_dir .. "/?.lua", tests_dir .. "/?.lua", tests_dir .. "/lib/?.lua", package.path }, ";")
+end
+
+setupPaths()
+require("mock_koreader")
+
+local OAuth = require("koassistant_openai_codex_oauth")
+local TestRunner = require("test_runner"):new()
+
+print("")
+print(string.rep("=", 50))
+print("  Unit Tests: OpenAI Codex OAuth")
+print(string.rep("=", 50))
+
+local function b64url(value)
+    local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    local bits = value:gsub(".", function(char)
+        local byte, out = char:byte(), ""
+        for i = 8, 1, -1 do
+            out = out .. ((byte % 2^i - byte % 2^(i - 1) > 0) and "1" or "0")
+        end
+        return out
+    end) .. "0000"
+    local encoded = bits:gsub("%d%d%d?%d?%d?%d?", function(chunk)
+        if #chunk < 6 then return "" end
+        local index = 0
+        for i = 1, 6 do
+            if chunk:sub(i, i) == "1" then index = index + 2^(6 - i) end
+        end
+        return alphabet:sub(index + 1, index + 1)
+    end)
+    return encoded:gsub("%+", "-"):gsub("/", "_")
+end
+
+local function makeJwt(payload)
+    return b64url('{"alg":"none"}') .. "." .. b64url(payload) .. ".sig"
+end
+
+TestRunner:test("user-code request matches OpenAI's Codex endpoint", function()
+    local req = OAuth.buildUserCodeRequest()
+    TestRunner:assertEqual(req.url, "https://auth.openai.com/api/accounts/deviceauth/usercode", "endpoint")
+    TestRunner:assertEqual(req.headers["Content-Type"], "application/json", "content type")
+    TestRunner:assertTrue(req.body:find('"client_id":"app_EMoamEEZ73f0CkXaXp7hrann"', 1, true) ~= nil, "client id")
+end)
+
+TestRunner:test("poll request carries device_auth_id and user_code", function()
+    local req = OAuth.buildPollRequest("device_123", "ABCD-EFGH")
+    TestRunner:assertTrue(req.body:find('"device_auth_id":"device_123"', 1, true) ~= nil, "device auth id")
+    TestRunner:assertTrue(req.body:find('"user_code":"ABCD-EFGH"', 1, true) ~= nil, "user code")
+    TestRunner:assertTrue(req.body:find("device_code", 1, true) == nil, "generic RFC device_code must not be sent")
+end)
+
+TestRunner:test("authorization-code exchange includes OpenAI-provided PKCE verifier", function()
+    local req = OAuth.buildTokenExchangeRequest("auth_code", "pkce_verifier")
+    TestRunner:assertTrue(req.body:find("grant_type=authorization_code", 1, true) ~= nil, "grant")
+    TestRunner:assertTrue(req.body:find("code=auth_code", 1, true) ~= nil, "code")
+    TestRunner:assertTrue(req.body:find("code_verifier=pkce_verifier", 1, true) ~= nil, "verifier")
+    TestRunner:assertTrue(req.body:find("redirect_uri=https%3A%2F%2Fauth.openai.com%2Fdeviceauth%2Fcallback", 1, true) ~= nil, "redirect")
+end)
+
+TestRunner:test("refresh request preserves rotating-token compatibility", function()
+    local req = OAuth.buildRefreshRequest("refresh_123")
+    TestRunner:assertTrue(req.body:find("grant_type=refresh_token", 1, true) ~= nil, "grant")
+    TestRunner:assertTrue(req.body:find("refresh_token=refresh_123", 1, true) ~= nil, "refresh token")
+    TestRunner:assertTrue(req.body:find("redirect_uri", 1, true) == nil, "refresh omits redirect URI")
+end)
+
+TestRunner:test("JWT parser reads nested OpenAI auth claim", function()
+    local token = makeJwt('{"exp":1893456000,"https://api.openai.com/auth":{"chatgpt_account_id":"acct_42"}}')
+    local payload = OAuth.parseJwtPayload(token)
+    TestRunner:assertEqual(payload.exp, 1893456000, "expiry")
+    TestRunner:assertEqual(payload.chatgpt_account_id, "acct_42", "account id")
+end)
+
+TestRunner:test("JWT parser rejects malformed tokens", function()
+    TestRunner:assertEqual(OAuth.parseJwtPayload("not-a-jwt"), nil, "bad token")
+    TestRunner:assertEqual(OAuth.parseJwtPayload("a.b.c"), nil, "bad payload")
+end)
+
+TestRunner:test("token normalization derives expiry/account and keeps old refresh token", function()
+    local token = makeJwt('{"exp":1893456000,"https://api.openai.com/auth":{"chatgpt_account_id":"acct_99"}}')
+    local auth = OAuth.normalizeTokenSet({ access_token = token }, "old_refresh", 1000)
+    TestRunner:assertEqual(auth.expires_at, 1893456000, "expiry")
+    TestRunner:assertEqual(auth.chatgpt_account_id, "acct_99", "account")
+    TestRunner:assertEqual(auth.refresh_token, "old_refresh", "fallback refresh")
+end)
+
+TestRunner:test("token normalization falls back to expires_in", function()
+    local auth = OAuth.normalizeTokenSet({ access_token = "opaque", refresh_token = "r", expires_in = 3600, chatgpt_account_id = "acct" }, nil, 1000)
+    TestRunner:assertEqual(auth.expires_at, 4600, "ttl converted")
+end)
+
+TestRunner:test("refresh decision honors expiry skew", function()
+    TestRunner:assertTrue(OAuth.shouldRefresh(nil, 1000), "missing")
+    TestRunner:assertTrue(OAuth.shouldRefresh({ access_token = "a", expires_at = 1299 }, 1000, 300), "inside skew")
+    TestRunner:assertFalse(OAuth.shouldRefresh({ access_token = "a", expires_at = 1401 }, 1000, 300), "outside skew")
+end)
+
+TestRunner:test("async token refresh schedules subprocess and saves rotated tokens", function()
+    local features = {
+        openai_codex_oauth = {
+            access_token = "expired_access",
+            refresh_token = "old_refresh",
+            expires_at = 1,
+            chatgpt_account_id = "acct_old",
+        },
+    }
+    local flushed = false
+    local settings = {
+        readSetting = function(_self, key) return key == "features" and features or nil end,
+        saveSetting = function(_self, key, value) if key == "features" then features = value end end,
+        flush = function() flushed = true end,
+    }
+    local pending
+    OAuth._setAsyncRunnerForTests(function(request, callback)
+        pending = { request = request, callback = callback }
+        return 77
+    end)
+
+    local callback_auth, callback_err
+    local pid = OAuth.resolveAccessTokenAsync(settings, function(auth, err)
+        callback_auth, callback_err = auth, err
+    end)
+    TestRunner:assertEqual(pid, 77, "subprocess pid returned")
+    TestRunner:assertEqual(callback_auth, nil, "callback waits for subprocess")
+    TestRunner:assertTrue(pending.request.body:find("refresh_token=old_refresh", 1, true) ~= nil, "refresh request")
+
+    local rotated_access = makeJwt('{"exp":1893456000,"https://api.openai.com/auth":{"chatgpt_account_id":"acct_new"}}')
+    pending.callback({
+        status_code = 200,
+        body = string.format('{"access_token":"%s","refresh_token":"new_refresh"}', rotated_access),
+    })
+    TestRunner:assertEqual(callback_err, nil, "no refresh error")
+    TestRunner:assertEqual(callback_auth.refresh_token, "new_refresh", "rotated refresh token")
+    TestRunner:assertEqual(callback_auth.chatgpt_account_id, "acct_new", "new account claim")
+    TestRunner:assertTrue(flushed, "refreshed credentials flushed")
+    TestRunner:assertEqual(features.openai_codex_oauth.refresh_token, "new_refresh", "refreshed credentials saved")
+    OAuth._setAsyncRunnerForTests(nil)
+end)
+
+TestRunner:test("polling treats 403/404 as pending and 429 as slow_down", function()
+    TestRunner:assertEqual(OAuth.classifyPollResponse(403, "").status, "pending", "403")
+    TestRunner:assertEqual(OAuth.classifyPollResponse(404, "").status, "pending", "404")
+    TestRunner:assertEqual(OAuth.classifyPollResponse(429, "").status, "slow_down", "429")
+end)
+
+TestRunner:test("poll success requires authorization_code and code_verifier", function()
+    local result = OAuth.classifyPollResponse(200, '{"authorization_code":"code","code_verifier":"verifier","code_challenge":"challenge"}')
+    TestRunner:assertEqual(result.status, "authorized", "status")
+    TestRunner:assertEqual(result.authorization_code, "code", "code")
+    TestRunner:assertEqual(result.code_verifier, "verifier", "verifier")
+    TestRunner:assertEqual(OAuth.classifyPollResponse(200, '{"authorization_code":"code"}').status, "error", "missing verifier")
+end)
+
+TestRunner:test("device dialog text displays URL code expiry and status", function()
+    local text = OAuth.buildDeviceDialogText("ABCD-EFGH", "Not authorized yet.")
+    TestRunner:assertTrue(text:find("https://auth.openai.com/codex/device", 1, true) ~= nil, "verification URL")
+    TestRunner:assertTrue(text:find("ABCD-EFGH", 1, true) ~= nil, "device code")
+    TestRunner:assertTrue(text:find("15 minutes", 1, true) ~= nil, "expiry guidance")
+    TestRunner:assertTrue(text:find("Not authorized yet.", 1, true) ~= nil, "status")
+end)
+
+TestRunner:test("interactive connect waits for KOReader network gate", function()
+    local previous = package.loaded["ui/network/manager"]
+    local gate_calls = 0
+    package.loaded["ui/network/manager"] = {
+        runWhenConnected = function(_self, _callback)
+            gate_calls = gate_calls + 1
+            -- Deliberately do not invoke callback: no dialog or network request may start.
+        end,
+    }
+    OAuth.startInteractiveConnect({ settings = {} })
+    package.loaded["ui/network/manager"] = previous
+    TestRunner:assertEqual(gate_calls, 1, "network gate")
+end)
+
+TestRunner:test("interactive flow keeps one device dialog and polls only on Check", function()
+    local module_names = {
+        "ui/network/manager", "ui/widget/buttondialog", "ui/widget/notification",
+        "ui/widget/infomessage", "ui/uimanager", "device",
+    }
+    local previous = {}
+    for _, name in ipairs(module_names) do previous[name] = package.loaded[name] end
+
+    local shown, closed, pending, terminated = {}, {}, {}, {}
+    local ffiutil = package.loaded["ffi/util"]
+    local previous_terminate = ffiutil.terminateSubProcess
+    ffiutil.terminateSubProcess = function(pid) terminated[#terminated + 1] = pid end
+    package.loaded["ui/uimanager"] = {
+        show = function(_self, widget) shown[#shown + 1] = widget end,
+        close = function(_self, widget) closed[#closed + 1] = widget end,
+        scheduleIn = function() end,
+    }
+    package.loaded["ui/widget/buttondialog"] = {
+        new = function(_self, opts)
+            function opts:setTitle(title) self.title = title end
+            return opts
+        end,
+    }
+    package.loaded["ui/widget/notification"] = { new = function(_self, opts) return opts end }
+    package.loaded["ui/widget/infomessage"] = { new = function(_self, opts) return opts end }
+    package.loaded["ui/network/manager"] = {
+        runWhenConnected = function(_self, callback) callback() end,
+    }
+    package.loaded["device"] = {
+        input = { setClipboardText = function() end },
+    }
+
+    OAuth._setAsyncRunnerForTests(function(request, callback)
+        pending[#pending + 1] = { request = request, callback = callback }
+        return 100 + #pending
+    end)
+
+    local settings = {
+        readSetting = function() return {} end,
+        saveSetting = function() end,
+        flush = function() end,
+    }
+    OAuth.startInteractiveConnect({ settings = settings })
+    TestRunner:assertEqual(#pending, 1, "only user-code request starts automatically")
+    pending[1].callback({
+        status_code = 200,
+        body = '{"device_auth_id":"device_1","user_code":"ABCD-EFGH","interval":5}',
+    })
+
+    local device_dialog = shown[#shown]
+    TestRunner:assertTrue(device_dialog.title:find("ABCD-EFGH", 1, true) ~= nil, "code shown")
+    TestRunner:assertFalse(device_dialog.dismissable, "explicit Cancel required")
+    TestRunner:assertEqual(#pending, 1, "no automatic authorization poll")
+
+    device_dialog.buttons[1][2].callback()
+    TestRunner:assertEqual(#pending, 2, "Check starts one poll")
+    pending[2].callback({ status_code = 403, body = "" })
+    TestRunner:assertEqual(shown[#shown], device_dialog, "same dialog remains visible")
+    TestRunner:assertTrue(device_dialog.title:find("Not authorized yet", 1, true) ~= nil, "pending status")
+
+    device_dialog.buttons[1][2].callback()
+    device_dialog.buttons[1][2].callback()
+    TestRunner:assertEqual(#pending, 3, "repeated tap cannot overlap a poll")
+    device_dialog.buttons[2][1].callback()
+    TestRunner:assertEqual(terminated[#terminated], 103, "Cancel terminates active poll")
+    local shown_before_stale_callback = #shown
+    pending[3].callback({ status_code = 403, body = "" })
+    TestRunner:assertEqual(#shown, shown_before_stale_callback, "post-cancel callback ignored")
+
+    OAuth._setAsyncRunnerForTests(nil)
+    ffiutil.terminateSubProcess = previous_terminate
+    for _, name in ipairs(module_names) do package.loaded[name] = previous[name] end
+end)
+
+return TestRunner:summary()

--- a/tests/unit/test_openai_responses.lua
+++ b/tests/unit/test_openai_responses.lua
@@ -26,6 +26,7 @@ local ResponseParser = require("koassistant_api.response_parser")
 local StreamHandler = require("stream_handler")
 local DebugUtils = require("koassistant_debug_utils")
 local ToolWire = require("koassistant_api.tool_wire")
+local json = require("json")
 local TestRunner = require("test_runner"):new()
 
 print("")
@@ -565,6 +566,94 @@ TestRunner:test("tool_wire: chat shape untouched by the Responses branch", funct
     TestRunner:assertEqual(#messages, 2, "assistant echo + tool result")
     TestRunner:assertEqual(messages[1].role, "assistant", "chat echo shape")
     TestRunner:assertEqual(messages[2].tool_call_id, "call_9", "chat result shape")
+end)
+
+--------------------------------------------------------------------------------
+print("\n  [Responses SSE collection]")
+--------------------------------------------------------------------------------
+
+TestRunner:test("SSE collector rebuilds output items from output_item.done events", function()
+    local body = table.concat({
+        'event: response.output_item.done',
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"search_book","arguments":"{\\"query\\":\\"whale\\"}"}}',
+        '',
+        'event: response.completed',
+        'data: {"type":"response.completed","response":{"status":"completed","output":[],"usage":{"total_tokens":12}}}',
+        '',
+    }, "\n")
+    local decoded = json.decode(ResponseParser.collectResponsesSSE(body))
+    TestRunner:assertEqual(decoded.status, "completed", "terminal status")
+    TestRunner:assertEqual(decoded.output[1].type, "function_call", "output item recovered")
+    TestRunner:assertEqual(decoded.output[1].call_id, "call_1", "call id recovered")
+    TestRunner:assertEqual(decoded.usage.total_tokens, 12, "terminal metadata preserved")
+end)
+
+TestRunner:test("SSE collector preserves incomplete terminal responses", function()
+    local body = table.concat({
+        'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_partial","type":"message","content":[{"type":"output_text","text":"partial"}]}}',
+        '',
+        'data: {"type":"response.incomplete","response":{"status":"incomplete","output":[],"incomplete_details":{"reason":"max_output_tokens"}}}',
+        '',
+    }, "\n")
+    local decoded = json.decode(ResponseParser.collectResponsesSSE(body))
+    TestRunner:assertEqual(decoded.status, "incomplete", "terminal status")
+    TestRunner:assertEqual(decoded.output[1].content[1].text, "partial", "partial output recovered")
+    TestRunner:assertEqual(decoded.incomplete_details.reason, "max_output_tokens", "truncation reason preserved")
+end)
+
+TestRunner:test("SSE collector merges terminal-only items and dedupes completed items", function()
+    local body = table.concat({
+        'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"search_book","arguments":"{}"}}',
+        '',
+        'data: {"type":"response.output_item.done","output_index":1,"item":{"id":"msg_1","type":"message","content":[{"type":"output_text","text":"final answer"}]}}',
+        '',
+        'data: {"type":"response.completed","response":{"status":"completed","output":[{"id":"msg_1","type":"message","content":[{"type":"output_text","text":"final answer"}]},{"id":"msg_terminal_only","type":"message","content":[{"type":"output_text","text":"terminal only"}]}]}}',
+        '',
+        'data: [DONE]',
+        '',
+    }, "\r\n")
+    local decoded = json.decode(ResponseParser.collectResponsesSSE(body))
+    TestRunner:assertEqual(#decoded.output, 3, "done and terminal items merged without duplicates")
+    TestRunner:assertEqual(decoded.output[1].id, "fc_1", "done-event order preserved")
+    TestRunner:assertEqual(decoded.output[2].id, "msg_1", "duplicate terminal item omitted")
+    TestRunner:assertEqual(decoded.output[3].id, "msg_terminal_only", "terminal-only item preserved")
+end)
+
+TestRunner:test("SSE collector inserts done items by output index around terminal reasoning", function()
+    local body = table.concat({
+        'data: {"type":"response.output_item.done","output_index":1,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"search_book","arguments":"{}"}}',
+        '',
+        'data: {"type":"response.output_item.done","output_index":2,"item":{"id":"msg_1","type":"message","content":[{"type":"output_text","text":"final answer"}]}}',
+        '',
+        'data: {"type":"response.completed","response":{"status":"completed","output":[{"id":"rs_1","type":"reasoning","encrypted_content":"opaque"},{"id":"msg_1","type":"message","content":[{"type":"output_text","text":"final answer"}]}]}}',
+        '',
+    }, "\n")
+    local decoded = json.decode(ResponseParser.collectResponsesSSE(body))
+    TestRunner:assertEqual(#decoded.output, 3, "reasoning, function call, and message retained")
+    TestRunner:assertEqual(decoded.output[1].type, "reasoning", "terminal reasoning remains before call")
+    TestRunner:assertEqual(decoded.output[2].type, "function_call", "done call inserted at output index")
+    TestRunner:assertEqual(decoded.output[3].type, "message", "terminal message remains after call")
+end)
+
+TestRunner:test("SSE collector preserves provider error without a terminal response", function()
+    local body = table.concat({
+        'data: {"type":"error","error":{"type":"server_error","message":"boom"}}',
+        '',
+    }, "\n")
+    local decoded = json.decode(ResponseParser.collectResponsesSSE(body))
+    TestRunner:assertEqual(decoded.status, "failed", "synthetic failed response")
+    TestRunner:assertEqual(decoded.error.message, "boom", "provider error preserved")
+    TestRunner:assertEqual(#decoded.output, 0, "failed response has empty output")
+end)
+
+TestRunner:test("SSE collector preserves response.failed error without response object", function()
+    local body = table.concat({
+        'data: {"type":"response.failed","error":{"code":"rate_limit_exceeded","message":"slow down"}}',
+        '',
+    }, "\n")
+    local decoded = json.decode(ResponseParser.collectResponsesSSE(body))
+    TestRunner:assertEqual(decoded.status, "failed", "synthetic failed response")
+    TestRunner:assertEqual(decoded.error.code, "rate_limit_exceeded", "failure code preserved")
 end)
 
 return TestRunner:summary()

--- a/tests/unit/test_storage_registry.lua
+++ b/tests/unit/test_storage_registry.lua
@@ -269,9 +269,11 @@ TestRunner:test("SETTINGS_SUBKEYS has the five non-config buckets, non-empty", f
     end
 end)
 
-TestRunner:test("api_keys is classified as a credential sub-key", function()
+TestRunner:test("api_keys and subscription OAuth are classified as credential sub-keys", function()
     TestRunner:assertTrue(listContains(Registry.SETTINGS_SUBKEYS.credentials, "api_keys"),
         "api_keys must be in SETTINGS_SUBKEYS.credentials")
+    TestRunner:assertTrue(listContains(Registry.SETTINGS_SUBKEYS.credentials, "openai_codex_oauth"),
+        "openai_codex_oauth must be in SETTINGS_SUBKEYS.credentials")
 end)
 
 TestRunner:test("custom_domains is an asset (consistency with custom_behaviors)", function()

--- a/tests/unit/test_tool_wire.lua
+++ b/tests/unit/test_tool_wire.lua
@@ -45,6 +45,12 @@ TestRunner:test("wave-1 providers alias the openai chat-wire adapter", function(
     TestRunner:assertFalse(ToolWire.hasAdapter("zai"), "zai stays out of wave 1")
 end)
 
+TestRunner:test("OpenAI Subscription reuses Responses replay after transport collection", function()
+    TestRunner:assertTrue(ToolWire.hasAdapter("openai_codex"), "adapter registered")
+    TestRunner:assertTrue(ToolWire.adapters.openai_codex == ToolWire.adapters.openai,
+        "same Responses replay shape")
+end)
+
 TestRunner:test("openai adapter echo keeps reasoning_content (DeepSeek V3.2+ replay contract)", function()
     local messages = {}
     local raw = { role = "assistant", content = nil, reasoning_content = "thinking...", tool_calls = {


### PR DESCRIPTION
## Summary

Add an **OpenAI Subscription** provider that uses OpenAI Codex device authorization and the ChatGPT Codex Responses backend, allowing eligible ChatGPT subscribers to use KOAssistant without a separate OpenAI API key.

The integration is explicitly labeled unofficial: it identifies itself as KOAssistant, does not impersonate the Codex CLI, and warns during connection that backend changes may break it.

## What changed

### Subscription authentication

- add a Codex-compatible provider and request handler
- add OAuth device-code login, token refresh, account extraction, and settings persistence
- make the connection flow safe for Kindle/KOReader:
  - use KOReader's normal network gate
  - display the verification URL and one-time code on-device
  - never attempt to launch a browser on the e-reader
  - poll only when the user taps **Check authorization**
  - prevent overlapping requests and ignore stale callbacks after cancellation
- surface the provider as **OpenAI Subscription** across provider/model selectors
- reuse OpenAI model constraints and reasoning profiles
- treat OAuth tokens as credentials in backup/restore and reset behavior

### Web search and book tools

Follow-up backend probes confirmed that the subscription backend supports the Responses features KOAssistant needs:

- hosted `web_search` with light/default/thorough search depth
- `url_citation` annotations and source harvesting
- function tools with `tool_choice: "required"`
- tool-result replay with `tool_choice: "none"`
- encrypted reasoning content for stateless tool replay

The backend requires `stream: true` on every request. KOAssistant therefore always streams on the wire, while a Codex-local subprocess path buffers and normalizes SSE for callers that require a complete response, including non-streaming chats and AI Book Tools gather/interactive rounds.

Responses event normalization is centralized in `response_parser.lua`. It handles completed, incomplete, failed, and error events; reconstructs output from `response.output_item.done`; merges terminal-only items; deduplicates overlapping items; and preserves protocol `output_index` ordering for reasoning/function-call replay.

- register OpenAI Subscription in the web-search capability source of truth
- reuse the existing OpenAI Responses ToolWire adapter after transport normalization
- preserve existing web provenance and book-tool replay paths
- send an honest `KOAssistant/<version>` user agent and `originator: koassistant`
- add an unofficial-service/breakage warning at the device authorization consent point

## Security and compatibility

- access and refresh tokens are never rendered or logged
- ordinary backups exclude subscription tokens
- credential-inclusive backups can explicitly include and restore them
- token refresh runs only after KOReader confirms network availability
- no browser-launch path is used
- no Codex CLI identity is spoofed
- the integration remains unofficial and may require maintenance if OpenAI changes the service

The device authorization protocol and 15-minute lifetime match OpenAI's current open-source Codex implementation. Hosted search/tool compatibility is based on live subscription-backend probes rather than a claim that the private backend is part of the public API contract.

## Testing

Docker-backed Lua 5.4 verification:

```text
OpenAI Codex handler:             7/7 passed
OpenAI Responses API:            53/53 passed
ToolWire adapters:               10/10 passed
OpenAI Codex OAuth:              15/15 passed
Full unit suite:                 zero failures
All tracked Lua files (luac -p): passed
git diff --check:                passed
Tracked worktree mutation check: passed
```

Independent pre-commit review found no blocker, high, medium, or low findings and returned **proud-to-submit**.

Manual KOReader checks passed for the connection warning, ordinary streaming, streaming-disabled collection, web search with sources, cancellation/stale-callback behavior, and restart persistence. Final device checks for the two AI Book Tools modes (Gather then answer and Interactive agentic loop) are still pending.
